### PR TITLE
Fix oracle error on 2 reentrancy tests

### DIFF
--- a/smartbugs-curated/0.4.x/test/reentrancy/etherstore_test.js
+++ b/smartbugs-curated/0.4.x/test/reentrancy/etherstore_test.js
@@ -78,10 +78,10 @@ describe("Reentrancy Attack for etherstore.sol", function () {
 
     // Verify the attack was successful
 
-    // victim has lost more funds than the withdrawal
-    expect(victimBalance).to.be.below(ethers.parseEther("6"));
+    // victim has lost more funds than the hacker's balance (7-2=5)
+    expect(victimBalance).to.be.below(ethers.parseEther("5"));
 
-    // hacker has more than the withdrawal
-    expect(hackerBalance).to.be.above(ethers.parseEther("1"));
+    // hacker has more than the initial depost: 2
+    expect(hackerBalance).to.be.above(ethers.parseEther("2"));
   });
 });

--- a/smartbugs-curated/0.4.x/test/reentrancy/reentrance_test.js
+++ b/smartbugs-curated/0.4.x/test/reentrancy/reentrance_test.js
@@ -76,10 +76,10 @@ describe("Reentrancy Attack for reentrance.sol", function () {
 
     // Verify the attack was successful
 
-    // victim has lost more funds than the withdrawal
-    expect(victimBalance).to.be.below(ethers.parseEther("8"));
+    // victim has lost more funds than the hacker's balance (9-4=5)
+    expect(victimBalance).to.be.below(ethers.parseEther("5"));
 
-    // hacker has more than the withdrawal
-    expect(hackerBalance).to.be.above(ethers.parseEther("1"));
+    // hacker has more than the initial deposit of 4
+    expect(hackerBalance).to.be.above(ethers.parseEther("4"));
   });
 });


### PR DESCRIPTION
2 test on the reentrancy category had an oracle that was reflecting if there could be reentrant calls instead of actual funds losses.

Details on :
https://github.com/ASSERT-KTH/sb-heists/issues/40