### PR TITLE
Update proxy_test.js

### DIFF
--- a/smartbugs-curated/0.4.x/test/access_control/proxy_test.js
+++ b/smartbugs-curated/0.4.x/test/access_control/proxy_test.js
@@ -44,27 +44,16 @@ describe("attack access_control/proxy.sol", function () {
     const { victim, attacker } = await loadFixture(deployContracts);
 
     const attackerInterface = new ethers.Interface(["function benign()"]);
-
     const data = attackerInterface.encodeFunctionData("benign");
+    
+    // oracle: check that the owner can call forward()
     await expect(victim.forward(attacker.target, data)).to.not.be.reverted;
   });
 
   it("exploit access control vulnerability", async function () {
     const { victim, attacker } = await loadFixture(deployContracts);
-    const victim_addr = await victim.getAddress();
-    const attacker_addr = await attacker.getAddress();
-
-    const victimeBalanceBefore = await ethers.provider.getBalance(victim_addr);
-    expect(victimeBalanceBefore).to.equal(amount);
-    const attackerBalanceBefore =
-      await ethers.provider.getBalance(attacker_addr);
-    expect(attackerBalanceBefore).to.equal(0);
-
-    await attacker.attack();
-    const victimBalanceAfter = await ethers.provider.getBalance(victim_addr);
-    expect(victimBalanceAfter).to.equal(0);
-    const attackerBalanceAfter =
-      await ethers.provider.getBalance(attacker_addr);
-    expect(attackerBalanceAfter).to.equal(amount);
+    
+    // oracle: check that the forward function can be called by non-owner, the attacker
+    expect( await attacker.attack() ).to.not.be.reverted;
   });
 });


### PR DESCRIPTION
Proposed fix for the wrong oracle on an access control exploit, proxy_test.sol.

According to our plausible analysis, this exploit was not doing the correct exploit check.

@mokita-j  
Can you confirm and review the proposed fix?

Here is my reasoning extracted from our shared spreadsheet:
The forward method should have been protected from being called by external contracts, instead, the patch changes delegate to call only. 
The exploit should check for access control instead. This correlates with the fix on the contract's source: https://smartcontractsecurity.github.io/SWC-registry/docs/SWC-112#proxysol