### PR TITLE
Fix: Evaluator contract-file input

### DIFF
--- a/evaluator/README.md
+++ b/evaluator/README.md
@@ -1,6 +1,7 @@
 # Patch Evaluator
 
 A tool for evaluating smart contract patches by running test suites and analyzing results.
+This tool currently supports the follwing dataset: `smartbugs-curated/0.4.x/contracts/dataset`.
 
 ## Prerequisites
 
@@ -42,7 +43,7 @@ The evaluator can be run from the command line with the following arguments:
 python src/main.py \
     --format <solidity|bytecode> \
     --patch <path-to-patch-file> \
-    --contract-file <path-to-contract> \
+    --contract-file <contract-from-dataset> \
     --main-contract <contract-name>
 ```
 
@@ -50,7 +51,7 @@ python src/main.py \
 
 - `--format`: The format of the patch file (choices: 'solidity' or 'bytecode')
 - `--patch`: Path to the patch file that will be evaluated
-- `--contract-file`: Path to the original smart contract file
+- `--contract-file`: Contract in `smartbugs-curated/0.4.x/contracts/dataset`. Required format `<vulnerability-type>/<filename>`.
 - `--main-contract`: Name of the main contract to be patched
 
 ### Example
@@ -58,9 +59,9 @@ python src/main.py \
 ```bash
 python src/main.py \
     --format solidity \
-    --patch ./patches/fix.sol \
-    --contract-file ./contracts/vulnerable.sol \
-    --main-contract VulnerableContract
+    --patch ./example/reentrancy_simple_patch.sol \
+    --contract-file reentrance/reentrancy_simple.sol \
+    --main-contract Reentrance
 ```
 
 ## Output
@@ -75,16 +76,17 @@ The tool will output evaluation results including:
 Example output:
 ```
 Evaluation Results:
-Contract File: ./contracts/vulnerable.sol
-Patch File: ./patches/fix.sol
-Total Tests: 10
-Passed Tests: 8
-Sanity Success: True
+Contract File: reentrancy/reentrancy_simple.sol
+Patch File: ./examples/reentrancy_simple_patch.sol
+Total Tests: 2
+Passed Tests: 1
+Sanity Success: 1
 Sanity Failures: 0
 
-Exploit Test Failures:
-- Test case #3: Invalid state after transfer
-- Test case #7: Reentrancy vulnerability still present
+Exploit Test Failures (1):
+- Exploit file: reentrancy/reentrancy_simple_test.js
+  Contract File: reentrancy/reentrancy_simple.sol
+  Error: Transaction reverted without a reason string
 ```
 
 ## Development

--- a/evaluator/examples/reentrancy_simple_patch.sol
+++ b/evaluator/examples/reentrancy_simple_patch.sol
@@ -1,0 +1,28 @@
+/*
+ * @source: https://github.com/trailofbits/not-so-smart-contracts/blob/master/reentrancy/Reentrancy.sol
+ * @author: -
+ * @vulnerable_at_lines: 24
+ */
+
+ pragma solidity ^0.4.15;
+
+ contract Reentrance {
+     mapping (address => uint) userBalance;
+
+     function getBalance(address u) constant returns(uint){
+         return userBalance[u];
+     }
+
+     function addToBalance() payable{
+         userBalance[msg.sender] += msg.value;
+     }
+
+     function withdrawBalance(){
+         uint balance = userBalance[msg.sender];
+         userBalance[msg.sender] = 0;
+         
+         if( ! (msg.sender.call.value(balance)() ) ){
+             throw;
+         }
+     }
+ }

--- a/evaluator/src/core/patch_evaluator.py
+++ b/evaluator/src/core/patch_evaluator.py
@@ -3,20 +3,32 @@ from models.test_result import TestResult
 from core.file_manager import FileManager
 from core.strategy_factory import PatchStrategyFactory
 from testing.hardhat_runner import HardhatTestRunner
+from exceptions import PatchValidationError
+import os
 import logging
 
 class PatchEvaluator:
     def __init__(self, base_directory: str):
         self.file_manager = FileManager(base_directory)
+        self.dataset_dir = os.path.abspath(os.path.join(base_directory, "contracts", "dataset")).replace(os.sep, '/')
+        self.dataset_files = []
+        for root, _, files in os.walk(self.dataset_dir):
+            for file in files:
+                if file.endswith(".sol"):
+                    parent_dir = os.path.basename(root)
+                    self.dataset_files.append(os.path.join(parent_dir, file).replace(os.sep, '/'))
         self.patch_factory = PatchStrategyFactory()
         self.test_runner = HardhatTestRunner(base_directory)
         self.logger = logging.getLogger(__name__)
 
     def evaluate_patch(self, patch: Patch) -> TestResult:
         strategy = self.patch_factory.create_strategy(patch)
-        self.logger.info(f"Evaluating patch: {patch.path} for contract: {patch.contract_file}")
+        normalized_contract_file = patch.contract_file.replace(os.sep, '/')
+        self.logger.info(f"Evaluating patch: {patch.path} for contract: {normalized_contract_file}")
         
         try:
+            if normalized_contract_file not in self.dataset_files:
+                raise PatchValidationError(f"Contract file {normalized_contract_file} not found in dataset({self.dataset_dir}).")
             contract_path = strategy.contract_path(patch)
             self.logger.debug(f"Backing up contract at: {contract_path}")
             self.file_manager.backup(contract_path)
@@ -32,17 +44,9 @@ class PatchEvaluator:
 
             self.logger.info(f"Evaluation complete. Passed tests: {test_result.passed_tests}/{test_result.total_tests}")
             return test_result
-
+        
         except Exception as e:
             self.logger.error(f"Error during patch evaluation: {str(e)}")
             self.file_manager.restore(strategy.contract_path(patch))
-            return TestResult(
-                failures_sanity=list(e),
-                failures_exploits=[0],
-                total_tests=0,
-                passed_tests=0,
-                sanity_success=0,
-                sanity_failures=0
-            )
-        finally:
             self.file_manager.remove_backup()
+            raise e

--- a/evaluator/src/models/patch.py
+++ b/evaluator/src/models/patch.py
@@ -7,6 +7,21 @@ class Patch:
     contract_file: str
     main: str
     format: PatchFormat
+
+    def __post_init__(self):
+        self._validate_format()
+
+    def _validate_format(self) -> None:
+        if isinstance(self.format, PatchFormat):
+            if self.format == PatchFormat.SOLIDITY_PATCH:
+                if not self.path.endswith('.sol'):
+                    raise ValueError(f"Patch file must be a Solidity file (.sol): {self.path}")
+            elif self.format == PatchFormat.BYTECODE_PATCH:
+                if not self.path.endswith('.bin'):
+                    raise ValueError(f"Patch file must be a Bytecode file (.bin): {self.path}")
+        else:
+            raise ValueError(f"Invalid patch format: {self.format}. Must be one of {list(PatchFormat)}")
+
     def get_contract_file(self) -> str:
         return self.contract_file
 

--- a/evaluator/src/models/test_result.py
+++ b/evaluator/src/models/test_result.py
@@ -29,9 +29,6 @@ class TestResult:
     def get_failed_tests(self) -> int:
         return self.failed_tests
     
-    def get_sanity_failures(self) -> List[str]:
-        return self.failures_sanity
-    
     def get_failed_results(self) -> List[str]:
         return self.failed_results
     


### PR DESCRIPTION
This PR refines the validation logic for the `--contract-file` input argument in the evaluator.

- The argument now **only accepts paths to Solidity contracts** that exist under [`smartbugs-curated/0.4.x/contracts/dataset`](https://github.com/ASSERT-KTH/sb-heists/tree/main/smartbugs-curated/0.4.x/contracts/dataset).
- Accepted values must follow the relative format:  `<vulnerability-type>/<filename>`
- Any inputs that do not match this pattern or do not correspond to an existing contract are **excluded from patching and exploit testing**.

This ensures the evaluator only processes valid dataset contracts and prevents errors caused by invalid paths.

