### PR TITLE
Replace "Sanity Check" with "Functional Check"

### DIFF
--- a/evaluator/README.md
+++ b/evaluator/README.md
@@ -70,7 +70,7 @@ The tool will output evaluation results including:
 - Contract and patch file information
 - Total number of tests run
 - Number of passed tests
-- Sanity check results
+- Functional check results
 - Details of any test failures
 
 Example output:
@@ -80,8 +80,8 @@ Contract File: reentrancy/reentrancy_simple.sol
 Patch File: ./examples/reentrancy_simple_patch.sol
 Total Tests: 2
 Passed Tests: 1
-Sanity Success: 1
-Sanity Failures: 0
+Functional Check Success: 1
+Fuctional Check Failures: 0
 
 Exploit Test Failures (1):
 - Exploit file: reentrancy/reentrancy_simple_test.js

--- a/evaluator/src/main.py
+++ b/evaluator/src/main.py
@@ -44,12 +44,12 @@ def main():
         print(f"Patch File: {result.patch_path}")
         print(f"Total Tests: {result.total_tests}")
         print(f"Passed Tests: {result.passed_tests}")
-        print(f"Sanity Success: {result.sanity_success}")
-        print(f"Sanity Failures: {result.sanity_failures}")
+        print(f"Functional Check Success: {result.functional_success}")
+        print(f"Fuctional Check Failures: {result.functional_failures}")
         
-        if result.failed_sanity_results:
-            print("\nSanity Test Failures:")
-            for failure in result.failed_sanity_results:
+        if result.failed_functional_results:
+            print("\nFunctional Check Failures:")
+            for failure in result.failed_functional_results:
                 print(f"- {failure}")
         
         if result.failed_results:

--- a/evaluator/src/models/test_result.py
+++ b/evaluator/src/models/test_result.py
@@ -8,9 +8,9 @@ class TestResult:
     total_tests: int
     passed_tests: int
     failed_tests: int
-    sanity_success: int
-    sanity_failures: int
-    failed_sanity_results: List[str]
+    functional_success: int
+    functional_failures: int
+    failed_functional_results: List[str]
     failed_results: List[str]
     passed_results: List[str]
 
@@ -36,4 +36,4 @@ class TestResult:
         return self.passed_results
     
     def fully_repaired(self) -> bool:
-        return self.sanity_failures == 0 and self.passed_tests - self.sanity_success == 0
+        return self.functional_failures == 0 and self.passed_tests - self.functional_success == 0

--- a/evaluator/src/testing/hardhat_runner.py
+++ b/evaluator/src/testing/hardhat_runner.py
@@ -65,9 +65,9 @@ class HardhatTestRunner:
             total_tests=test_results["totalTests"],
             passed_tests=test_results["passingTests"],
             failed_tests=test_results["failingTests"],
-            sanity_success=test_results["passedSanity"],
-            sanity_failures=test_results["failedSanity"],
-            failed_sanity_results=test_results["failedSanityTests"],
+            functional_success=test_results["passedFunctionalCheck"],
+            functional_failures=test_results["failedFunctionalCheck"],
+            failed_functional_results=test_results["failedFunctionalCheckResults"],
             failed_results=test_results["failedResults"],
             passed_results=test_results["passedResults"]
         )

--- a/smartbugs-curated/0.4.x/README.md
+++ b/smartbugs-curated/0.4.x/README.md
@@ -71,7 +71,7 @@ npx hardhat test test/reentrancy/simple_dao_test.js
 
 Each test file contains two types of tests:
 
-### 1. Sanity Tests
+### 1. Functional Check Tests
 Verify normal contract behavior without exploiting vulnerabilities. These ensure the contract works as intended under normal circumstances.
 
 ### 2. Exploit Tests
@@ -80,7 +80,7 @@ Demonstrate the vulnerability by executing attack sequences that exploit the sec
 Example output:
 ```bash
     Reentrancy Attack for simpleDAO.sol
-    ✔ sanity check: reentrancy/simpleDAO.sol (632ms)
+    ✔ functional check: reentrancy/simpleDAO.sol (632ms)
     ✔ should successfully drain funds through reentrancy attack
 
   2 passing (651ms)

--- a/smartbugs-curated/0.4.x/scripts/CustomReporter.js
+++ b/smartbugs-curated/0.4.x/scripts/CustomReporter.js
@@ -18,9 +18,9 @@ class CustomReporter extends Spec {
     let currentFile = null;
     let allTestsPassed = true;
     let allFiles = 0;
-    let failedSanity = 0;
-    const failedSanityTests = [];
-    let passedSanity = 0;
+    let failedFunctionalCheck = 0;
+    const failedFunctionalChecks = [];
+    let passedFunctionalCheck = 0;
     const passedResults = [];
     const failedResults = [];
 
@@ -54,8 +54,8 @@ class CustomReporter extends Spec {
         stack: err.stack,
       };
       if (test.title.includes("functional check")) {
-        failedSanity += 1;
-        failedSanityTests.push(result);
+        failedFunctionalCheck += 1;
+        failedFunctionalChecks.push(result);
       } else {
         failedResults.push(result);
       }
@@ -72,7 +72,7 @@ class CustomReporter extends Spec {
         state: test.state,
       };
       if (test.title.includes("functional check")) {
-        passedSanity += 1;
+        passedFunctionalCheck += 1;
       } else {
         passedResults.push(result);
       }
@@ -101,7 +101,7 @@ class CustomReporter extends Spec {
       );
       const formattedMessage3 = Base.color(
         "fail",
-        `Total failed functional tests: ${failedSanity}/${allFiles}`,
+        `Total failed functional tests: ${failedFunctionalCheck}/${allFiles}`,
       );
       // // Log the formatted message
       console.log(`${formattedMessage}`);
@@ -117,9 +117,9 @@ class CustomReporter extends Spec {
           totalFiles: allFiles,
           passingFiles: passingFiles,
           failingFiles: failedFiles,
-          failedSanity: failedSanity,
-          passedSanity: passedSanity,
-          failedSanityTests: failedSanityTests,
+          failedFunctionalCheck: failedFunctionalCheck,
+          passedFunctionalCheck: passedFunctionalCheck,
+          failedFunctionalChecks: failedFunctionalChecks,
           passedResults: passedResults,
           failedResults: failedResults,
         };

--- a/smartbugs-curated/0.4.x/scripts/CustomReporter.js
+++ b/smartbugs-curated/0.4.x/scripts/CustomReporter.js
@@ -19,7 +19,7 @@ class CustomReporter extends Spec {
     let allTestsPassed = true;
     let allFiles = 0;
     let failedFunctionalCheck = 0;
-    const failedFunctionalChecks = [];
+    const failedFunctionalCheckResults = [];
     let passedFunctionalCheck = 0;
     const passedResults = [];
     const failedResults = [];
@@ -55,7 +55,7 @@ class CustomReporter extends Spec {
       };
       if (test.title.includes("functional check")) {
         failedFunctionalCheck += 1;
-        failedFunctionalChecks.push(result);
+        failedFunctionalCheckResults.push(result);
       } else {
         failedResults.push(result);
       }
@@ -119,7 +119,7 @@ class CustomReporter extends Spec {
           failingFiles: failedFiles,
           failedFunctionalCheck: failedFunctionalCheck,
           passedFunctionalCheck: passedFunctionalCheck,
-          failedFunctionalChecks: failedFunctionalChecks,
+          failedFunctionalCheckResults: failedFunctionalCheckResults,
           passedResults: passedResults,
           failedResults: failedResults,
         };

--- a/smartbugs-curated/0.4.x/scripts/test-results.json
+++ b/smartbugs-curated/0.4.x/scripts/test-results.json
@@ -5,9 +5,9 @@
   "totalFiles": 91,
   "passingFiles": 91,
   "failingFiles": 0,
-  "failedSanity": 0,
-  "passedSanity": 95,
-  "failedSanityTests": [],
+  "failedFunctionalCheck": 0,
+  "passedFunctionalCheck": 95,
+  "failedFunctionalChecks": [],
   "passedResults": [
     {
       "title": "exploit access control vulnerability",

--- a/smartbugs-curated/0.4.x/scripts/test-results.json
+++ b/smartbugs-curated/0.4.x/scripts/test-results.json
@@ -7,7 +7,7 @@
   "failingFiles": 0,
   "failedFunctionalCheck": 0,
   "passedFunctionalCheck": 95,
-  "failedFunctionalChecks": [],
+  "failedFunctionalCheckResults": [],
   "passedResults": [
     {
       "title": "exploit access control vulnerability",


### PR DESCRIPTION
Replaces all instances of "sanity check" with "functional check" to align with terminology used in the preprint and ensure consistency across the codebase.
Affects:
- Test results parser
- Evaluator tool

closes #55 